### PR TITLE
Fixed chunks urls when public path is not defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.0.1
+
+#### Fixes
+
+* Fixed chunks urls when public path is not defined [#3](https://github.com/yoriiis/chunks-webpack-plugin/issues/3)
+
 # 3.0.0
 
 #### Updates

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![chunks-webpack-plugin](https://img.shields.io/badge/chunks--webpack--plugin-v3.0.0-1a6bac.svg?style=flat-square)](https://github.com/yoriiis/chunks-webpack-plugin)
+[![chunks-webpack-plugin](https://img.shields.io/badge/chunks--webpack--plugin-v3.0.1-1a6bac.svg?style=flat-square)](https://github.com/yoriiis/chunks-webpack-plugin)
 [![Npm downloads](https://img.shields.io/npm/dm/chunks-webpack-plugin?color=1a6bac&label=npm%20downloads&style=flat-square)](https://npmjs.com/package/chunks-webpack-plugin)
 
 # ChunksWebpackPlugin

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 /**
  * @license MIT
  * @name ChunksWebpackPlugin
- * @version 3.0.0
+ * @version 3.0.1
  * @author: Yoriiis aka Joris DANIEL <joris.daniel@gmail.com>
  * @description:
  * {@link https://github.com/yoriiis/chunks-webpack-plugins}
@@ -46,7 +46,7 @@ module.exports = class ChunksWebpackPlugin {
 	_done(stats) {
 
 		// Get publicPath from Webpack and add slashes suffix if necessary
-		this.publicPath = stats.compilation.options.output.publicPath;
+		this.publicPath = stats.compilation.options.output.publicPath || '';
 		if (this.publicPath) {
 			if (this.publicPath.substr(-1) !== '/') {
 				this.publicPath = `${this.publicPath}/`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chunks-webpack-plugin",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Easily create HTML files with all chunks by entrypoint (based on Webpack chunkGroups)",
   "keywords": [
     "chunks",


### PR DESCRIPTION
This fixes the case where `publicPath` is not defined in the Webpack configuration and is used as `undefined` value in chunks urls (issue #3).