### PR TITLE
[#3] - Fixed strict node engine version break with different node version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.2.1
+
+#### Fixes
+
+* Fixed strict node engine version break with different node version [#6](https://github.com/yoriiis/chunks-webpack-plugin/issues/6)
+
+
 # 3.2.0
 
 #### New features

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p>
-	<img alt="TravisCI" src="https://img.shields.io/badge/chunks--webpack--plugin-v3.2.0-ff7f15.svg?style=for-the-badge">
+	<img alt="TravisCI" src="https://img.shields.io/badge/chunks--webpack--plugin-v3.2.1-ff7f15.svg?style=for-the-badge">
 	<a href="https://travis-ci.com/yoriiis/chunks-webpack-plugin">
 		<img alt="TravisCI" src="https://img.shields.io/travis/yoriiis/chunks-webpack-plugin?style=for-the-badge">
 	</a>

--- a/dist/index.js
+++ b/dist/index.js
@@ -3,7 +3,7 @@
 /**
  * @license MIT
  * @name ChunksWebpackPlugin
- * @version 3.2.0
+ * @version 3.2.1
  * @author: Yoriiis aka Joris DANIEL <joris.daniel@gmail.com>
  * @description:
  * {@link https://github.com/yoriiis/chunks-webpack-plugins}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "chunks-webpack-plugin",
-	"version": "3.2.0",
+	"version": "3.2.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "chunks-webpack-plugin",
-	"version": "3.2.0",
+	"version": "3.2.1",
 	"description": "Easily create HTML files with all chunks by entrypoint (based on Webpack chunkGroups)",
 	"keywords": [
 		"chunks",
@@ -36,7 +36,6 @@
 		"webpack": "^4.0.0"
 	},
 	"engines": {
-		"node": "8.11.2",
-		"npm": "5.6.0"
+		"node": ">=8.11.2"
 	}
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /**
  * @license MIT
  * @name ChunksWebpackPlugin
- * @version 3.2.0
+ * @version 3.2.1
  * @author: Yoriiis aka Joris DANIEL <joris.daniel@gmail.com>
  * @description:
  * {@link https://github.com/yoriiis/chunks-webpack-plugins}


### PR DESCRIPTION
This fixes the case where node engine is strict in the package.json. Updated it with a minimal version of `8.11.2` (issue #6).