### PR TITLE
make manifest and chunksFiles mutually exclusive

### DIFF
--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -211,6 +211,30 @@ describe('ChunksWebpackPlugin', () => {
 		expect(chunksWebpackPlugin.updateManifest).not.toHaveBeenCalled();
 	});
 
+	it('Initialize the hookCallback function with generating manifest and without generating chunk files', () => {
+		chunksWebpackPlugin.createHtmlChunksFiles = jest.fn();
+		chunksWebpackPlugin.updateManifest = jest.fn();
+
+		chunksWebpackPlugin.options.generateChunksManifest = true;
+		chunksWebpackPlugin.options.generateChunksFiles = false;
+		chunksWebpackPlugin.hookCallback(compilationWebpack);
+
+		expect(chunksWebpackPlugin.createHtmlChunksFiles).not.toHaveBeenCalled();
+		expect(chunksWebpackPlugin.updateManifest).toHaveBeenCalled();
+	});
+
+	it('Initialize the hookCallback function with generating chunk files and without generating manifest', () => {
+		chunksWebpackPlugin.createHtmlChunksFiles = jest.fn();
+		chunksWebpackPlugin.updateManifest = jest.fn();
+
+		chunksWebpackPlugin.options.generateChunksManifest = false;
+		chunksWebpackPlugin.options.generateChunksFiles = true;
+		chunksWebpackPlugin.hookCallback(compilationWebpack);
+
+		expect(chunksWebpackPlugin.createHtmlChunksFiles).toHaveBeenCalled();
+		expect(chunksWebpackPlugin.updateManifest).not.toHaveBeenCalled();
+	});
+
 	it('Initialize the hookCallback function with wrong returns of customFormatTags', () => {
 		chunksWebpackPlugin.createHtmlChunksFiles = jest.fn();
 		utils.setError = jest.fn();

--- a/src/index.js
+++ b/src/index.js
@@ -55,35 +55,38 @@ module.exports = class ChunksWebpackPlugin {
 			const files = this.getFiles({ entryName: entryName, compilation: compilation });
 
 			// Check if entrypoint contains files and if chunks files generation is enabled
-			if (files.length && this.options.generateChunksFiles) {
+			if (files.length) {
 				const chunksSorted = this.sortsChunksByType({
 					files: files,
 					publicPath: publicPath
 				});
 
-				let tagsHTML = null;
+				// Check if html chunk files option is enabled
+				if (this.options.generateChunksFiles) {
+					let tagsHTML = null;
 
-				// The user prefers to generate his own HTML tags, use his object
-				if (this.options.customFormatTags instanceof Function) {
-					// Change context of the function, to allow access to this class
-					tagsHTML = this.options.customFormatTags.call(this, chunksSorted, files);
+					// The user prefers to generate his own HTML tags, use his object
+					if (this.options.customFormatTags instanceof Function) {
+						// Change context of the function, to allow access to this class
+						tagsHTML = this.options.customFormatTags.call(this, chunksSorted, files);
 
-					// Check if datas are correctly formatted
-					if (!this.customFormatTagsDatasIsValid(tagsHTML)) {
-						utils.setError(
-							'ChunksWebpackPlugin::customFormatTags return invalid object'
-						);
+						// Check if datas are correctly formatted
+						if (!this.customFormatTagsDatasIsValid(tagsHTML)) {
+							utils.setError(
+								'ChunksWebpackPlugin::customFormatTags return invalid object'
+							);
+						}
+					} else {
+						// Default behavior, generate HTML tags with templateStyle and templateScript
+						tagsHTML = this.generateTags(chunksSorted);
 					}
-				} else {
-					// Default behavior, generate HTML tags with templateStyle and templateScript
-					tagsHTML = this.generateTags(chunksSorted);
-				}
 
-				this.createHtmlChunksFiles({
-					entryName: entryName,
-					tagsHTML: tagsHTML,
-					outputPath: outputPath
-				});
+					this.createHtmlChunksFiles({
+						entryName: entryName,
+						tagsHTML: tagsHTML,
+						outputPath: outputPath
+					});
+				}
 
 				// Check if manifest option is enabled
 				if (this.options.generateChunksManifest) {


### PR DESCRIPTION
The options `generateChunksManifest` and `generateChunksFiles` can operate
independently now.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Docs/guides updated
  - [ ] Example created on CodePen
- [ ] Reviewed by contributors

fixes #53 