### PR TITLE
[#66] - Fix the assets generation outside the webpack compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Removes
 
-- Remove the `outputPath` parameter. Templates are generated in the the webpack output path. Use the `filename` to customize the output directory.
+- Remove the `outputPath` parameter. Templates are generated in the webpack output path. Use the `filename` to customize the output directory.
 - Remove the `fileExtension` parameter.
 - Remove the `fs-extra` package in favor of the file system exposed by the webpack compiler. It use the `graceful-fs` package.
 - Remove the utils and move useful functions into the main file

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ module.exports = {
 
 HTML files are built in the output path directory with the rest of the webpack output.
 
-Now you can include the outputted HTML files into your HTML page templates. You can do it with e.g. Twig.
+Now you can include the generated HTML files into your HTML page templates. You can do it with e.g. Twig.
 
 **main-styles.html**
 
@@ -87,15 +87,17 @@ You can pass a configuration object to `ChunksWebpackPlugin` to override the def
 
 `string = '[name]-[type].html'`
 
-Tells the plugin whether to personalize the filename of the generated files.
+Tells the plugin whether to personalize the filename of the generated files. Files are processed by the webpack compilation and generated in the output path directory.
+
+> 💡 `[name]` is automatically replaced by the entrypoint name and `[type]` by `styles|scripts`.
+>
+> The filename can contain directories, which will be created automatically.
 
 ```js
 new ChunksWebpackPlugin({
   filename: 'templates/[name]-[type].html'
 });
 ```
-
-> `[name]` is automatically replaced by the entrypoint name and `[type]` by `styles|scripts`.
 
 ### `templateStyle`
 
@@ -109,7 +111,7 @@ new ChunksWebpackPlugin({
 });
 ```
 
-> Keep the `{{chunk}}` placeholder, it is automatically replaced by the concatenation of the webpack public path and the chunk filename.
+> 💡 Keep the `{{chunk}}` placeholder, it is automatically replaced by the concatenation of the webpack public path and the chunk filename.
 
 ### `templateScript`
 
@@ -123,7 +125,21 @@ new ChunksWebpackPlugin({
 });
 ```
 
-> Keep the `{{chunk}}` placeholder, it is automatically replaced by the concatenation of the webpack public path and the chunk filename.
+> 💡 Keep the `{{chunk}}` placeholder, it is automatically replaced by the concatenation of the webpack public path and the chunk filename.
+
+### `outputPath`
+
+`string = null`
+
+Tells the plugin whether to personalize the output path of generated files (need absolute path). By default the plugin will use `options.output.path` from the [Webpack configuration](https://webpack.js.org/configuration/output/#outputpath).
+
+> 💡 Can be used to generate files outside the webpack output path directory. With this option, files are not processed by the webpack compilation.
+
+```javascript
+new ChunksWebpackPlugin({
+  outputPath: path.resolve(__dirname, `./templates`)
+});
+```
 
 ### `customFormatTags`
 
@@ -149,7 +165,7 @@ new ChunksWebpackPlugin({
 });
 ```
 
-> The arrow function syntax allow you to access the class properties.
+> 💡 The arrow function syntax allow you to access the class properties.
 >
 > The function provides more flexibility by replacing the default behavior. Follow the example above to make sure it works.
 
@@ -174,7 +190,7 @@ The list of the chunks sorted by type: `styles` and `scripts`.
 
 The object is included in every single ChunkGroup. The variable contains all information about the current entry point; log it on the console for more details.
 
-> Use this variable only for a full customization if the `chunksSorted` variable does not meet your needs.
+> 💡 Use this variable only for a full customization if the `chunksSorted` variable does not meet your needs.
 
 ### `generateChunksManifest`
 
@@ -215,7 +231,7 @@ new ChunksWebpackPlugin({
 });
 ```
 
-> When set to `false`, HTML files will not be generated. It can only be useful together with `generateChunksManifest` option set to `true` for custom generation of the HTML files.
+> 💡 When set to `false`, HTML files will not be generated. It can only be useful together with `generateChunksManifest` option set to `true` for custom generation of the HTML files.
 
 ### Caching
 

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -50,7 +50,6 @@ module.exports = (env, argv) => {
 			}),
 			new ChunksWebpackPlugin({
 				filename: 'templates/[name]-[type].html',
-				emitAssetsWithCompilation: true,
 				generateChunksManifest: true,
 				generateChunksFiles: true,
 				customFormatTags: (chunksSorted, Entrypoint) => {

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -50,6 +50,7 @@ module.exports = (env, argv) => {
 			}),
 			new ChunksWebpackPlugin({
 				filename: 'templates/[name]-[type].html',
+				emitAssetsWithCompilation: true,
 				generateChunksManifest: true,
 				generateChunksFiles: true,
 				customFormatTags: (chunksSorted, Entrypoint) => {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -25,6 +25,8 @@ interface Manifest {
 declare const _default: {
     new (options?: {}): {
         options: {
+            outputPath: null | string;
+            emitAssetsWithCompilation: boolean;
             filename: string;
             templateStyle: string;
             templateScript: string;
@@ -33,11 +35,13 @@ declare const _default: {
             generateChunksFiles: boolean;
         };
         manifest: Manifest;
+        fs: any;
         compilation: any;
         isWebpack4: Boolean;
         entryNames: Array<string>;
         publicPath: string;
         outputPath: null | string;
+        outpathFromFilename: string;
         /**
          * Apply function is automatically called by the Webpack main compiler
          *
@@ -75,6 +79,19 @@ declare const _default: {
          * @return {String} The output path
          */
         getOutputPath(): string | null;
+        /**
+         * Get the output path inside the filename if exist
+         * Filename can contains directory (automatically created by the compilation
+         *
+         * @returns {String} The outpath path extract from the filename
+         */
+        getOutputPathFromFilename(): string;
+        /**
+         * Check if the outputPath is valid, a string and absolute
+         *
+         * @returns {Boolean} outputPath is valid
+         */
+        isValidOutputPath(): boolean;
         /**
          * Get entrypoint names from the compilation
          *
@@ -166,6 +183,22 @@ declare const _default: {
             entryName: string;
             htmlTags: HtmlTags;
         }): void;
+        /**
+         * Create asset by the webpack compilation (default) or Node.js FS
+         * @param {Object} options
+         * @param {String} filename Filename
+         * @param {String} output File content
+         */
+        createAsset({ filename, output }: {
+            filename: string;
+            output: string;
+        }): void;
+        /**
+         * Get the output file path (outPath + filename)
+         * @param {String} filename The filename
+         * @returns {String} The output file path
+         */
+        getOutputFilePath(filename: string): string;
         /**
          * Throw an error
          *

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -5,7 +5,7 @@
  * @author: Yoriiis aka Joris DANIEL <joris.daniel@gmail.com>
  * @description: ChunksWebpackPlugin create HTML files to serve your webpack bundles. It is very convenient with multiple entrypoints and it works without configuration.
  * {@link https://github.com/yoriiis/chunks-webpack-plugins}
- * @copyright 2020 Joris DANIEL
+ * @copyright 2021 Joris DANIEL
  **/
 import { Compiler } from 'webpack';
 interface Chunks {
@@ -30,7 +30,6 @@ declare const _default: {
     new (options?: {}): {
         options: {
             outputPath: null | string;
-            emitAssetsWithCompilation: boolean;
             filename: string;
             templateStyle: string;
             templateScript: string;
@@ -169,7 +168,8 @@ declare const _default: {
             htmlTags: HtmlTags;
         }): void;
         /**
-         * Create asset by the webpack compilation (default) or the webpack built-in Node.js File System
+         * Create asset by the webpack compilation or the webpack built-in Node.js File System
+         * The outputPath parameter allows to override the default webpack output path
          * @param {Object} options
          * @param {String} options.filename Filename
          * @param {String} options.output File content

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -48,13 +48,11 @@ declare const _default: {
         outpathFromFilename: string;
         /**
          * Apply function is automatically called by the Webpack main compiler
-         *
          * @param {Object} compiler The Webpack compiler variable
          */
         apply(compiler: Compiler): void;
         /**
          * Hook expose by the Webpack compiler
-         *
          * @param {Object} compilation The Webpack compilation variable
          */
         hookCallback(compilation: object): void;
@@ -65,40 +63,34 @@ declare const _default: {
         addAssets(): void;
         /**
          * Process for each entry
-    
          * @param {String} entryName Entrypoint name
          */
         processEntry(entryName: string): void;
         /**
          * Get the public path from Webpack configuation
          * and add slash at the end if necessary
-         *
          * @return {String} The public path
          */
         getPublicPath(): string;
         /**
          * Get the output path from Webpack configuation
          * or from constructor options
-         *
          * @return {String} The output path
          */
         getOutputPath(): string | null;
         /**
-         * Get the output path inside the filename if exist
-         * Filename can contains directory (automatically created by the compilation
-         *
+         * Get the output path inside the filename if it exists
+         * Filename can contain a directory (created automatically by the compilation)
          * @returns {String} The outpath path extract from the filename
          */
         getOutputPathFromFilename(): string;
         /**
          * Check if the outputPath is valid, a string and absolute
-         *
          * @returns {Boolean} outputPath is valid
          */
         isValidOutputPath(): boolean;
         /**
          * Get entrypoint names from the compilation
-         *
          * @return {Array} List of entrypoint names
          */
         getEntryNames(): Array<string>;
@@ -106,16 +98,14 @@ declare const _default: {
          * Get files list by entrypoint name
          *
          * @param {String} entryName Entrypoint name
-         *
          * @return {Array} List of entrypoint names
          */
         getFiles(entryName: string): Array<string>;
         /**
          * Get HTML tags from chunks
-         *
-         * @param {Object} chunks Chunks sorted by type (style, script)
-         * @param {Object} Entrypoint Entrypoint object part of a single ChunkGroup
-         *
+         * @param {Object} options
+         * @param {Object} options.chunks Chunks sorted by type (style, script)
+         * @param {Object} options.Entrypoint Entrypoint object part of a single ChunkGroup
          * @returns {String} HTML tags by entrypoints
          */
         getHtmlTags({ chunks, Entrypoint }: {
@@ -124,49 +114,40 @@ declare const _default: {
         }): undefined | HtmlTags;
         /**
          * Sorts all chunks by type (styles or scripts)
-         *
          * @param {Array} files List of files by entrypoint name
-         *
          * @returns {Object} All chunks sorted by extension type
          */
         sortsChunksByType(files: Array<string>): Chunks;
         /**
          * Generate HTML styles and scripts tags for each entrypoints
-         *
          * @param {Object} chunks The list of chunks of chunkGroups sorted by type
-         *
          * @returns {Object} HTML tags with all assets for an entrypoint and sorted by type
          */
         formatTags(chunks: Chunks): HtmlTags;
         /**
          * Check if the publicPath need an ending slash
-         *
          * @param {String} publicPath Public path
-         *
          * @returns {Boolean} The public path need an ending slash
          */
         isPublicPathNeedsEndingSlash(publicPath: string): boolean;
         /**
          * Check if file extension correspond to the type parameter
-         *
          * @param {String} file File path
          * @param {String} type File extension
-         *
          * @returns {Boolean} File extension is valid
          */
         isValidExtensionByType(file: string, type: string): boolean;
         /**
          * Check if datas from customFormatTags are valid
-         *
          * @param {Object} htmlTags Formatted HTML tags by styles and scripts keys
          */
         isValidCustomFormatTagsDatas(htmlTags: HtmlTags): boolean;
         /**
          * Update the class property manifest
          * which contains all chunks informations by entrypoint
-         *
-         * @param {String} entryName Entrypoint name
-         * @param {Object} chunks List of styles and scripts chunks by entrypoint
+         * @param {Object} options
+         * @param {String} options.entryName Entrypoint name
+         * @param {Object} options.chunks List of styles and scripts chunks by entrypoint
          */
         updateManifest({ entryName, chunks }: {
             entryName: string;
@@ -179,19 +160,19 @@ declare const _default: {
         createChunksManifestFile(): void;
         /**
          * Create file with HTML tags for each entrypoints
-         *
-         * @param {String} entryName Entrypoint name
-         * @param {Object} htmlTags Generated HTML of script and styles tags
+         * @param {Object} options
+         * @param {String} options.entryName Entrypoint name
+         * @param {Object} options.htmlTags Generated HTML of script and styles tags
          */
         createHtmlChunksFiles({ entryName, htmlTags }: {
             entryName: string;
             htmlTags: HtmlTags;
         }): void;
         /**
-         * Create asset by the webpack compilation (default) or Node.js FS
+         * Create asset by the webpack compilation (default) or the webpack built-in Node.js File System
          * @param {Object} options
-         * @param {String} filename Filename
-         * @param {String} output File content
+         * @param {String} options.filename Filename
+         * @param {String} options.output File content
          */
         createAsset({ filename, output }: {
             filename: string;
@@ -205,7 +186,6 @@ declare const _default: {
         getOutputFilePath(filename: string): string;
         /**
          * Throw an error
-         *
          * @param {String} message Text to display in the error
          */
         setError(message: string): void;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -22,6 +22,10 @@ interface Manifest {
         scripts: Array<string>;
     };
 }
+interface Fs {
+    mkdir: Function;
+    writeFile: Function;
+}
 declare const _default: {
     new (options?: {}): {
         options: {
@@ -35,7 +39,7 @@ declare const _default: {
             generateChunksFiles: boolean;
         };
         manifest: Manifest;
-        fs: any;
+        fs: Fs;
         compilation: any;
         isWebpack4: Boolean;
         entryNames: Array<string>;

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,9 +25,11 @@ module.exports = /** @class */ (function () {
             filename: '[name]-[type].html',
             templateStyle: '<link rel="stylesheet" href="{{chunk}}" />',
             templateScript: '<script src="{{chunk}}"></script>',
+            outputPath: null,
             customFormatTags: false,
             generateChunksManifest: false,
-            generateChunksFiles: true
+            generateChunksFiles: true,
+            emitAssetsWithCompilation: true
         }, options);
         this.manifest = {};
         this.isWebpack4 = false;
@@ -50,6 +52,7 @@ module.exports = /** @class */ (function () {
      */
     ChunksWebpackPlugin.prototype.hookCallback = function (compilation) {
         this.compilation = compilation;
+        this.fs = this.compilation.compiler.outputFileSystem;
         if (this.isWebpack4) {
             this.addAssets();
         }
@@ -69,6 +72,7 @@ module.exports = /** @class */ (function () {
         var _this = this;
         this.publicPath = this.getPublicPath();
         this.outputPath = this.getOutputPath();
+        this.outpathFromFilename = this.getOutputPathFromFilename();
         this.entryNames = this.getEntryNames();
         this.entryNames
             .filter(function (entryName) { return _this.getFiles(entryName).length; })
@@ -122,7 +126,30 @@ module.exports = /** @class */ (function () {
      * @return {String} The output path
      */
     ChunksWebpackPlugin.prototype.getOutputPath = function () {
-        return this.compilation.options.output.path || '';
+        if (this.isValidOutputPath()) {
+            return this.options.outputPath;
+        }
+        else {
+            return this.compilation.options.output.path || '';
+        }
+    };
+    /**
+     * Get the output path inside the filename if exist
+     * Filename can contains directory (automatically created by the compilation
+     *
+     * @returns {String} The outpath path extract from the filename
+     */
+    ChunksWebpackPlugin.prototype.getOutputPathFromFilename = function () {
+        var pathFromFilename = /(^\/?)(.*\/)/.exec(this.options.filename);
+        return pathFromFilename && pathFromFilename[2] !== '/' ? pathFromFilename[2] : '';
+    };
+    /**
+     * Check if the outputPath is valid, a string and absolute
+     *
+     * @returns {Boolean} outputPath is valid
+     */
+    ChunksWebpackPlugin.prototype.isValidOutputPath = function () {
+        return !!(this.options.outputPath && path.isAbsolute(this.options.outputPath));
     };
     /**
      * Get entrypoint names from the compilation
@@ -260,7 +287,10 @@ module.exports = /** @class */ (function () {
         var output = JSON.stringify(this.manifest, null, 2);
         // Expose the manifest file into the assets compilation
         // The file is automatically created by the compiler
-        this.compilation.emitAsset('chunks-manifest.json', new RawSource(output, false));
+        this.createAsset({
+            filename: 'chunks-manifest.json',
+            output: output
+        });
     };
     /**
      * Create file with HTML tags for each entrypoints
@@ -271,11 +301,53 @@ module.exports = /** @class */ (function () {
     ChunksWebpackPlugin.prototype.createHtmlChunksFiles = function (_a) {
         var entryName = _a.entryName, htmlTags = _a.htmlTags;
         if (htmlTags.scripts.length) {
-            this.compilation.emitAsset(this.options.filename.replace('[name]', entryName).replace('[type]', 'scripts'), new RawSource(htmlTags.scripts, false));
+            this.createAsset({
+                filename: this.options.filename
+                    .replace('[name]', entryName)
+                    .replace('[type]', 'scripts'),
+                output: htmlTags.scripts
+            });
         }
         if (htmlTags.styles.length) {
-            this.compilation.emitAsset(this.options.filename.replace('[name]', entryName).replace('[type]', 'styles'), new RawSource(htmlTags.styles, false));
+            this.createAsset({
+                filename: this.options.filename
+                    .replace('[name]', entryName)
+                    .replace('[type]', 'styles'),
+                output: htmlTags.styles
+            });
         }
+    };
+    /**
+     * Create asset by the webpack compilation (default) or Node.js FS
+     * @param {Object} options
+     * @param {String} filename Filename
+     * @param {String} output File content
+     */
+    ChunksWebpackPlugin.prototype.createAsset = function (_a) {
+        var _this = this;
+        var filename = _a.filename, output = _a.output;
+        if (this.options.emitAssetsWithCompilation) {
+            this.compilation.emitAsset(filename, new RawSource(output, false));
+        }
+        else {
+            this.fs.mkdir(this.options.outputPath + "/" + this.outpathFromFilename, { recursive: true }, function (error) {
+                if (error)
+                    throw error;
+                var filePath = _this.getOutputFilePath(filename);
+                _this.fs.writeFile(filePath, output, function (error) {
+                    if (error)
+                        throw error;
+                });
+            });
+        }
+    };
+    /**
+     * Get the output file path (outPath + filename)
+     * @param {String} filename The filename
+     * @returns {String} The output file path
+     */
+    ChunksWebpackPlugin.prototype.getOutputFilePath = function (filename) {
+        return "" + this.outputPath + (filename.substr(0, 1) === '/' ? '' : '/') + filename;
     };
     /**
      * Throw an error

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@
  * @author: Yoriiis aka Joris DANIEL <joris.daniel@gmail.com>
  * @description: ChunksWebpackPlugin create HTML files to serve your webpack bundles. It is very convenient with multiple entrypoints and it works without configuration.
  * {@link https://github.com/yoriiis/chunks-webpack-plugins}
- * @copyright 2020 Joris DANIEL
+ * @copyright 2021 Joris DANIEL
  **/
 var webpack = require('webpack');
 // webpack v4/v5 compatibility:
@@ -27,7 +27,6 @@ module.exports = /** @class */ (function () {
             templateScript: '<script src="{{chunk}}"></script>',
             outputPath: null,
             customFormatTags: false,
-            emitAssetsWithCompilation: true,
             generateChunksManifest: false,
             generateChunksFiles: true
         }, options);
@@ -299,7 +298,8 @@ module.exports = /** @class */ (function () {
         }
     };
     /**
-     * Create asset by the webpack compilation (default) or the webpack built-in Node.js File System
+     * Create asset by the webpack compilation or the webpack built-in Node.js File System
+     * The outputPath parameter allows to override the default webpack output path
      * @param {Object} options
      * @param {String} options.filename Filename
      * @param {String} options.output File content
@@ -307,11 +307,8 @@ module.exports = /** @class */ (function () {
     ChunksWebpackPlugin.prototype.createAsset = function (_a) {
         var _this = this;
         var filename = _a.filename, output = _a.output;
-        if (this.options.emitAssetsWithCompilation) {
-            this.compilation.emitAsset(filename, new RawSource(output, false));
-        }
-        else {
-            this.fs.mkdir(this.options.outputPath + "/" + this.outpathFromFilename, { recursive: true }, function (error) {
+        if (this.options.outputPath) {
+            this.fs.mkdir(this.outputPath + "/" + this.outpathFromFilename, { recursive: true }, function (error) {
                 if (error)
                     throw error;
                 var filePath = _this.getOutputFilePath(filename);
@@ -320,6 +317,9 @@ module.exports = /** @class */ (function () {
                         throw error;
                 });
             });
+        }
+        else {
+            this.compilation.emitAsset(filename, new RawSource(output, false));
         }
     };
     /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,9 +27,9 @@ module.exports = /** @class */ (function () {
             templateScript: '<script src="{{chunk}}"></script>',
             outputPath: null,
             customFormatTags: false,
+            emitAssetsWithCompilation: true,
             generateChunksManifest: false,
-            generateChunksFiles: true,
-            emitAssetsWithCompilation: true
+            generateChunksFiles: true
         }, options);
         this.manifest = {};
         this.isWebpack4 = false;
@@ -37,7 +37,6 @@ module.exports = /** @class */ (function () {
     }
     /**
      * Apply function is automatically called by the Webpack main compiler
-     *
      * @param {Object} compiler The Webpack compiler variable
      */
     ChunksWebpackPlugin.prototype.apply = function (compiler) {
@@ -47,7 +46,6 @@ module.exports = /** @class */ (function () {
     };
     /**
      * Hook expose by the Webpack compiler
-     *
      * @param {Object} compilation The Webpack compilation variable
      */
     ChunksWebpackPlugin.prototype.hookCallback = function (compilation) {
@@ -84,7 +82,6 @@ module.exports = /** @class */ (function () {
     };
     /**
      * Process for each entry
-
      * @param {String} entryName Entrypoint name
      */
     ChunksWebpackPlugin.prototype.processEntry = function (entryName) {
@@ -104,7 +101,6 @@ module.exports = /** @class */ (function () {
     /**
      * Get the public path from Webpack configuation
      * and add slash at the end if necessary
-     *
      * @return {String} The public path
      */
     ChunksWebpackPlugin.prototype.getPublicPath = function () {
@@ -122,7 +118,6 @@ module.exports = /** @class */ (function () {
     /**
      * Get the output path from Webpack configuation
      * or from constructor options
-     *
      * @return {String} The output path
      */
     ChunksWebpackPlugin.prototype.getOutputPath = function () {
@@ -134,9 +129,8 @@ module.exports = /** @class */ (function () {
         }
     };
     /**
-     * Get the output path inside the filename if exist
-     * Filename can contains directory (automatically created by the compilation
-     *
+     * Get the output path inside the filename if it exists
+     * Filename can contain a directory (created automatically by the compilation)
      * @returns {String} The outpath path extract from the filename
      */
     ChunksWebpackPlugin.prototype.getOutputPathFromFilename = function () {
@@ -145,7 +139,6 @@ module.exports = /** @class */ (function () {
     };
     /**
      * Check if the outputPath is valid, a string and absolute
-     *
      * @returns {Boolean} outputPath is valid
      */
     ChunksWebpackPlugin.prototype.isValidOutputPath = function () {
@@ -153,7 +146,6 @@ module.exports = /** @class */ (function () {
     };
     /**
      * Get entrypoint names from the compilation
-     *
      * @return {Array} List of entrypoint names
      */
     ChunksWebpackPlugin.prototype.getEntryNames = function () {
@@ -163,7 +155,6 @@ module.exports = /** @class */ (function () {
      * Get files list by entrypoint name
      *
      * @param {String} entryName Entrypoint name
-     *
      * @return {Array} List of entrypoint names
      */
     ChunksWebpackPlugin.prototype.getFiles = function (entryName) {
@@ -171,10 +162,9 @@ module.exports = /** @class */ (function () {
     };
     /**
      * Get HTML tags from chunks
-     *
-     * @param {Object} chunks Chunks sorted by type (style, script)
-     * @param {Object} Entrypoint Entrypoint object part of a single ChunkGroup
-     *
+     * @param {Object} options
+     * @param {Object} options.chunks Chunks sorted by type (style, script)
+     * @param {Object} options.Entrypoint Entrypoint object part of a single ChunkGroup
      * @returns {String} HTML tags by entrypoints
      */
     ChunksWebpackPlugin.prototype.getHtmlTags = function (_a) {
@@ -197,9 +187,7 @@ module.exports = /** @class */ (function () {
     };
     /**
      * Sorts all chunks by type (styles or scripts)
-     *
      * @param {Array} files List of files by entrypoint name
-     *
      * @returns {Object} All chunks sorted by extension type
      */
     ChunksWebpackPlugin.prototype.sortsChunksByType = function (files) {
@@ -215,9 +203,7 @@ module.exports = /** @class */ (function () {
     };
     /**
      * Generate HTML styles and scripts tags for each entrypoints
-     *
      * @param {Object} chunks The list of chunks of chunkGroups sorted by type
-     *
      * @returns {Object} HTML tags with all assets for an entrypoint and sorted by type
      */
     ChunksWebpackPlugin.prototype.formatTags = function (chunks) {
@@ -235,9 +221,7 @@ module.exports = /** @class */ (function () {
     };
     /**
      * Check if the publicPath need an ending slash
-     *
      * @param {String} publicPath Public path
-     *
      * @returns {Boolean} The public path need an ending slash
      */
     ChunksWebpackPlugin.prototype.isPublicPathNeedsEndingSlash = function (publicPath) {
@@ -245,10 +229,8 @@ module.exports = /** @class */ (function () {
     };
     /**
      * Check if file extension correspond to the type parameter
-     *
      * @param {String} file File path
      * @param {String} type File extension
-     *
      * @returns {Boolean} File extension is valid
      */
     ChunksWebpackPlugin.prototype.isValidExtensionByType = function (file, type) {
@@ -256,7 +238,6 @@ module.exports = /** @class */ (function () {
     };
     /**
      * Check if datas from customFormatTags are valid
-     *
      * @param {Object} htmlTags Formatted HTML tags by styles and scripts keys
      */
     ChunksWebpackPlugin.prototype.isValidCustomFormatTagsDatas = function (htmlTags) {
@@ -267,9 +248,9 @@ module.exports = /** @class */ (function () {
     /**
      * Update the class property manifest
      * which contains all chunks informations by entrypoint
-     *
-     * @param {String} entryName Entrypoint name
-     * @param {Object} chunks List of styles and scripts chunks by entrypoint
+     * @param {Object} options
+     * @param {String} options.entryName Entrypoint name
+     * @param {Object} options.chunks List of styles and scripts chunks by entrypoint
      */
     ChunksWebpackPlugin.prototype.updateManifest = function (_a) {
         var entryName = _a.entryName, chunks = _a.chunks;
@@ -294,9 +275,9 @@ module.exports = /** @class */ (function () {
     };
     /**
      * Create file with HTML tags for each entrypoints
-     *
-     * @param {String} entryName Entrypoint name
-     * @param {Object} htmlTags Generated HTML of script and styles tags
+     * @param {Object} options
+     * @param {String} options.entryName Entrypoint name
+     * @param {Object} options.htmlTags Generated HTML of script and styles tags
      */
     ChunksWebpackPlugin.prototype.createHtmlChunksFiles = function (_a) {
         var entryName = _a.entryName, htmlTags = _a.htmlTags;
@@ -318,10 +299,10 @@ module.exports = /** @class */ (function () {
         }
     };
     /**
-     * Create asset by the webpack compilation (default) or Node.js FS
+     * Create asset by the webpack compilation (default) or the webpack built-in Node.js File System
      * @param {Object} options
-     * @param {String} filename Filename
-     * @param {String} output File content
+     * @param {String} options.filename Filename
+     * @param {String} options.output File content
      */
     ChunksWebpackPlugin.prototype.createAsset = function (_a) {
         var _this = this;
@@ -351,7 +332,6 @@ module.exports = /** @class */ (function () {
     };
     /**
      * Throw an error
-     *
      * @param {String} message Text to display in the error
      */
     ChunksWebpackPlugin.prototype.setError = function (message) {

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -170,10 +170,10 @@ describe('ChunksWebpackPlugin constructor', () => {
 			templateStyle: '<link rel="stylesheet" href="{{chunk}}" />',
 			templateScript: '<script src="{{chunk}}"></script>',
 			outputPath: null,
+			emitAssetsWithCompilation: true,
 			generateChunksManifest: false,
 			generateChunksFiles: true,
-			customFormatTags: false,
-			emitAssetsWithCompilation: true
+			customFormatTags: false
 		});
 		expect(chunksWebpackPlugin.manifest).toEqual({});
 	});
@@ -681,7 +681,6 @@ describe('ChunksWebpackPlugin createAsset', () => {
 		chunksWebpackPlugin.outputPath = compilationWebpack.options.output.path;
 		chunksWebpackPlugin.outpathFromFilename = 'templates/';
 		chunksWebpackPlugin.fs = compilationWebpack.compiler.outputFileSystem;
-
 		chunksWebpackPlugin.options.outputPath = '/chunks-webpack-plugin/example/dist/templates';
 		chunksWebpackPlugin.options.emitAssetsWithCompilation = false;
 		chunksWebpackPlugin.createAsset({
@@ -714,7 +713,6 @@ describe('ChunksWebpackPlugin createAsset', () => {
 		chunksWebpackPlugin.outputPath = compilationWebpack.options.output.path;
 		chunksWebpackPlugin.outpathFromFilename = 'templates/';
 		chunksWebpackPlugin.fs = generateMockFs({ mkdirError: true });
-
 		chunksWebpackPlugin.options.outputPath = '/chunks-webpack-plugin/example/dist/templates';
 		chunksWebpackPlugin.options.emitAssetsWithCompilation = false;
 
@@ -734,7 +732,6 @@ describe('ChunksWebpackPlugin createAsset', () => {
 		chunksWebpackPlugin.outputPath = compilationWebpack.options.output.path;
 		chunksWebpackPlugin.outpathFromFilename = 'templates/';
 		chunksWebpackPlugin.fs = generateMockFs({ writeFileError: true });
-
 		chunksWebpackPlugin.options.outputPath = '/chunks-webpack-plugin/example/dist/templates';
 		chunksWebpackPlugin.options.emitAssetsWithCompilation = false;
 

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -170,7 +170,6 @@ describe('ChunksWebpackPlugin constructor', () => {
 			templateStyle: '<link rel="stylesheet" href="{{chunk}}" />',
 			templateScript: '<script src="{{chunk}}"></script>',
 			outputPath: null,
-			emitAssetsWithCompilation: true,
 			generateChunksManifest: false,
 			generateChunksFiles: true,
 			customFormatTags: false
@@ -682,7 +681,6 @@ describe('ChunksWebpackPlugin createAsset', () => {
 		chunksWebpackPlugin.outpathFromFilename = 'templates/';
 		chunksWebpackPlugin.fs = compilationWebpack.compiler.outputFileSystem;
 		chunksWebpackPlugin.options.outputPath = '/chunks-webpack-plugin/example/dist/templates';
-		chunksWebpackPlugin.options.emitAssetsWithCompilation = false;
 		chunksWebpackPlugin.createAsset({
 			filename: 'templates/app-a-scripts.html',
 			output: htmlTags.scripts
@@ -690,7 +688,7 @@ describe('ChunksWebpackPlugin createAsset', () => {
 
 		expect(chunksWebpackPlugin.compilation.emitAsset).not.toHaveBeenCalled();
 		expect(chunksWebpackPlugin.fs.mkdir).toHaveBeenCalledWith(
-			'/chunks-webpack-plugin/example/dist/templates/templates/',
+			'/chunks-webpack-plugin/example/dist/templates/',
 			{
 				recursive: true
 			},
@@ -714,7 +712,6 @@ describe('ChunksWebpackPlugin createAsset', () => {
 		chunksWebpackPlugin.outpathFromFilename = 'templates/';
 		chunksWebpackPlugin.fs = generateMockFs({ mkdirError: true });
 		chunksWebpackPlugin.options.outputPath = '/chunks-webpack-plugin/example/dist/templates';
-		chunksWebpackPlugin.options.emitAssetsWithCompilation = false;
 
 		expect(() => {
 			chunksWebpackPlugin.createAsset({

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -25,6 +25,7 @@ const { RawSource } = webpack.sources || require('webpack-sources');
 
 let chunksWebpackPlugin;
 let compilationWebpack;
+let mockFs;
 let entryNames;
 let files;
 let chunks;
@@ -98,6 +99,14 @@ entrypointsMap.set('app-c', {
 	},
 	getFiles: () => entrypointsMap.get('app-c').chunks.files
 });
+const generateMockFs = ({ mkdirError, writeFileError } = {}) => ({
+	mkdir: jest.fn().mockImplementation((path, options, callback) => {
+		mkdirError ? callback(new Error('mkdir error')) : callback();
+	}),
+	writeFile: jest.fn().mockImplementation((path, output, callback) => {
+		writeFileError ? callback(new Error('writeFile error')) : callback();
+	})
+});
 
 beforeEach(() => {
 	Entrypoint = entrypointsMap.get('app-a');
@@ -114,15 +123,20 @@ beforeEach(() => {
 			'<script defer src="https://cdn.domain.comjs/vendors~app-a~app-b~app-c.js"></script><script defer src="https://cdn.domain.comjs/app-a.js"></script>'
 	};
 
+	mockFs = generateMockFs();
+
 	compilationWebpack = {
 		assets: {},
 		entrypoints: entrypointsMap,
 		options: {
 			context: '/chunks-webpack-plugin/example',
 			output: {
-				path: '/chunks-webpack-plugin/example/dist/',
+				path: '/chunks-webpack-plugin/example/dist',
 				publicPath: '/dist/'
 			}
+		},
+		compiler: {
+			outputFileSystem: mockFs
 		},
 		emitAsset: jest.fn(),
 		hooks: {
@@ -141,6 +155,7 @@ describe('ChunksWebpackPlugin constructor', () => {
 			filename: 'templates/[name]-[type].html',
 			templateStyle: '<link rel="stylesheet" href="{{chunk}}" />',
 			templateScript: '<script src="{{chunk}}"></script>',
+			outputPath: null,
 			generateChunksManifest: true,
 			generateChunksFiles: true,
 			customFormatTags: expect.any(Function)
@@ -150,13 +165,15 @@ describe('ChunksWebpackPlugin constructor', () => {
 
 	it('Should initialize the constructor with default options', () => {
 		const instance = new ChunksWebpackPlugin();
-		expect(instance.options).toMatchObject({
+		expect(instance.options).toStrictEqual({
 			filename: '[name]-[type].html',
 			templateStyle: '<link rel="stylesheet" href="{{chunk}}" />',
 			templateScript: '<script src="{{chunk}}"></script>',
+			outputPath: null,
 			generateChunksManifest: false,
 			generateChunksFiles: true,
-			customFormatTags: false
+			customFormatTags: false,
+			emitAssetsWithCompilation: true
 		});
 		expect(chunksWebpackPlugin.manifest).toEqual({});
 	});
@@ -204,6 +221,7 @@ describe('ChunksWebpackPlugin hookCallback', () => {
 		chunksWebpackPlugin.hookCallback(compilationWebpack);
 
 		expect(chunksWebpackPlugin.compilation).toBe(compilationWebpack);
+		expect(chunksWebpackPlugin.fs).toBe(mockFs);
 		expect(chunksWebpackPlugin.addAssets).toHaveBeenCalled();
 		expect(chunksWebpackPlugin.compilation.hooks.processAssets.tap).not.toHaveBeenCalledWith();
 	});
@@ -227,8 +245,11 @@ describe('ChunksWebpackPlugin hookCallback', () => {
 
 describe('ChunksWebpackPlugin addAssets', () => {
 	it('Should call the addAssets function', () => {
-		chunksWebpackPlugin.getPublicPath = jest.fn();
-		chunksWebpackPlugin.getOutputPath = jest.fn();
+		chunksWebpackPlugin.getPublicPath = jest.fn().mockReturnValue('/dist/');
+		chunksWebpackPlugin.getOutputPath = jest
+			.fn()
+			.mockReturnValue('/chunks-webpack-plugin/example/dist');
+		chunksWebpackPlugin.getOutputPathFromFilename = jest.fn().mockReturnValue('templates/');
 		mockGetEntryNames(chunksWebpackPlugin, entryNames);
 		mockGetFiles(chunksWebpackPlugin, files);
 		chunksWebpackPlugin.processEntry = jest.fn();
@@ -238,6 +259,7 @@ describe('ChunksWebpackPlugin addAssets', () => {
 
 		expect(chunksWebpackPlugin.getPublicPath).toHaveBeenCalled();
 		expect(chunksWebpackPlugin.getOutputPath).toHaveBeenCalled();
+		expect(chunksWebpackPlugin.getOutputPathFromFilename).toHaveBeenCalled();
 		expect(chunksWebpackPlugin.getEntryNames).toHaveBeenCalled();
 		expect(chunksWebpackPlugin.getFiles).toHaveBeenCalledTimes(3);
 		expect(chunksWebpackPlugin.getFiles).toHaveBeenCalledWith('app-a');
@@ -248,6 +270,9 @@ describe('ChunksWebpackPlugin addAssets', () => {
 		expect(chunksWebpackPlugin.processEntry).toHaveBeenCalledWith('app-b');
 		expect(chunksWebpackPlugin.processEntry).toHaveBeenCalledWith('app-c');
 		expect(chunksWebpackPlugin.createChunksManifestFile).toHaveBeenCalled();
+		expect(chunksWebpackPlugin.publicPath).toBe('/dist/');
+		expect(chunksWebpackPlugin.outputPath).toBe('/chunks-webpack-plugin/example/dist');
+		expect(chunksWebpackPlugin.outpathFromFilename).toBe('templates/');
 	});
 
 	it('Should call the addAssets function without generateChunksManifest', () => {
@@ -367,17 +392,54 @@ describe('ChunksWebpackPlugin getPublicPath', () => {
 });
 
 describe('ChunksWebpackPlugin getOutputPath', () => {
-	it('Should call the getOutputPath function with valid outputPath', () => {
+	it('Should call the getOutputPath function with a valid outputPath from options', () => {
+		chunksWebpackPlugin.isValidOutputPath = jest.fn().mockReturnValue(true);
+
 		chunksWebpackPlugin.compilation = compilationWebpack;
+		chunksWebpackPlugin.options.outputPath = '/chunks-webpack-plugin/example/dist/templates';
 		const result = chunksWebpackPlugin.getOutputPath();
 
-		expect(result).toBe('/chunks-webpack-plugin/example/dist/');
+		expect(chunksWebpackPlugin.isValidOutputPath).toHaveBeenCalled();
+		expect(result).toBe('/chunks-webpack-plugin/example/dist/templates');
+	});
+
+	it('Should call the getOutputPath function with an invalid outputPath from options', () => {
+		chunksWebpackPlugin.compilation = compilationWebpack;
+		chunksWebpackPlugin.options.outputPath = 'chunks-webpack-plugin/example/dist/templates';
+		const result = chunksWebpackPlugin.getOutputPath();
+
+		expect(result).toBe('/chunks-webpack-plugin/example/dist');
 	});
 
 	it('Should call the getOutputPath function with an undefined value', () => {
 		chunksWebpackPlugin.compilation = compilationWebpack;
 		chunksWebpackPlugin.compilation.options.output.path = undefined;
 		const result = chunksWebpackPlugin.getOutputPath();
+
+		expect(result).toBe('');
+	});
+});
+
+describe('ChunksWebpackPlugin getOutputPathFromFilename', () => {
+	it('Should call the getOutputPathFromFilename function with an outpath inside the filename', () => {
+		chunksWebpackPlugin.compilation = compilationWebpack;
+		const result = chunksWebpackPlugin.getOutputPathFromFilename();
+
+		expect(result).toBe('templates/');
+	});
+
+	it('Should call the getOutputPathFromFilename function with a filename that starts with a slashe', () => {
+		chunksWebpackPlugin.compilation = compilationWebpack;
+		chunksWebpackPlugin.options.filename = '/[name]-[type].html';
+		const result = chunksWebpackPlugin.getOutputPathFromFilename();
+
+		expect(result).toBe('');
+	});
+
+	it('Should call the getOutputPathFromFilename function without an outpath inside the filename', () => {
+		chunksWebpackPlugin.compilation = compilationWebpack;
+		chunksWebpackPlugin.options.filename = '[name]-[type].html';
+		const result = chunksWebpackPlugin.getOutputPathFromFilename();
 
 		expect(result).toBe('');
 	});
@@ -556,6 +618,8 @@ describe('ChunksWebpackPlugin createChunksManifestFile', () => {
 
 describe('ChunksWebpackPlugin createHtmlChunksFiles', () => {
 	it('Should call the createHtmlChunksFiles function', () => {
+		chunksWebpackPlugin.createAsset = jest.fn();
+
 		chunksWebpackPlugin.compilation = compilationWebpack;
 		chunksWebpackPlugin.outputPath = '/dist/templates';
 
@@ -567,10 +631,12 @@ describe('ChunksWebpackPlugin createHtmlChunksFiles', () => {
 			}
 		});
 
-		expect(chunksWebpackPlugin.compilation.emitAsset).not.toHaveBeenCalled();
+		expect(chunksWebpackPlugin.createAsset).not.toHaveBeenCalled();
 	});
 
 	it('Should call the createHtmlChunksFiles function with scripts and styles', () => {
+		chunksWebpackPlugin.createAsset = jest.fn();
+
 		chunksWebpackPlugin.compilation = compilationWebpack;
 		chunksWebpackPlugin.outputPath = '/dist/templates';
 
@@ -579,15 +645,122 @@ describe('ChunksWebpackPlugin createHtmlChunksFiles', () => {
 			htmlTags
 		});
 
-		expect(chunksWebpackPlugin.compilation.emitAsset).toHaveBeenCalledTimes(2);
+		expect(chunksWebpackPlugin.createAsset).toHaveBeenCalledTimes(2);
+		expect(chunksWebpackPlugin.createAsset).toHaveBeenNthCalledWith(1, {
+			filename: 'templates/app-a-scripts.html',
+			output: htmlTags.scripts
+		});
+		expect(chunksWebpackPlugin.createAsset).toHaveBeenNthCalledWith(2, {
+			filename: 'templates/app-a-styles.html',
+			output: htmlTags.styles
+		});
+	});
+});
+
+describe('ChunksWebpackPlugin createAsset', () => {
+	it('Should call the createAsset function with the emitAsset', () => {
+		chunksWebpackPlugin.compilation = compilationWebpack;
+
+		chunksWebpackPlugin.createAsset({
+			filename: 'templates/app-a-scripts.html',
+			output: htmlTags.scripts
+		});
+
 		expect(chunksWebpackPlugin.compilation.emitAsset).toHaveBeenCalledWith(
 			'templates/app-a-scripts.html',
 			new RawSource(htmlTags.scripts, false)
 		);
-		expect(chunksWebpackPlugin.compilation.emitAsset).toHaveBeenCalledWith(
-			'templates/app-a-styles.html',
-			new RawSource(htmlTags.styles, false)
+	});
+
+	it('Should call the createAsset function with the Node.js FS', () => {
+		chunksWebpackPlugin.getOutputFilePath = jest
+			.fn()
+			.mockReturnValue('/chunks-webpack-plugin/example/dist/templates/app-a-scripts.html');
+
+		chunksWebpackPlugin.compilation = compilationWebpack;
+		chunksWebpackPlugin.outputPath = compilationWebpack.options.output.path;
+		chunksWebpackPlugin.outpathFromFilename = 'templates/';
+		chunksWebpackPlugin.fs = compilationWebpack.compiler.outputFileSystem;
+
+		chunksWebpackPlugin.options.outputPath = '/chunks-webpack-plugin/example/dist/templates';
+		chunksWebpackPlugin.options.emitAssetsWithCompilation = false;
+		chunksWebpackPlugin.createAsset({
+			filename: 'templates/app-a-scripts.html',
+			output: htmlTags.scripts
+		});
+
+		expect(chunksWebpackPlugin.compilation.emitAsset).not.toHaveBeenCalled();
+		expect(chunksWebpackPlugin.fs.mkdir).toHaveBeenCalledWith(
+			'/chunks-webpack-plugin/example/dist/templates/templates/',
+			{
+				recursive: true
+			},
+			expect.any(Function)
 		);
+		expect(chunksWebpackPlugin.getOutputFilePath).toHaveBeenCalledWith(
+			'templates/app-a-scripts.html'
+		);
+		expect(chunksWebpackPlugin.fs.writeFile).toHaveBeenCalledWith(
+			'/chunks-webpack-plugin/example/dist/templates/app-a-scripts.html',
+			htmlTags.scripts,
+			expect.any(Function)
+		);
+	});
+
+	it('Should call the createAsset function with the Node.js FS and mkdir error', () => {
+		chunksWebpackPlugin.getOutputFilePath = jest.fn();
+
+		chunksWebpackPlugin.compilation = compilationWebpack;
+		chunksWebpackPlugin.outputPath = compilationWebpack.options.output.path;
+		chunksWebpackPlugin.outpathFromFilename = 'templates/';
+		chunksWebpackPlugin.fs = generateMockFs({ mkdirError: true });
+
+		chunksWebpackPlugin.options.outputPath = '/chunks-webpack-plugin/example/dist/templates';
+		chunksWebpackPlugin.options.emitAssetsWithCompilation = false;
+
+		expect(() => {
+			chunksWebpackPlugin.createAsset({
+				filename: 'templates/app-a-scripts.html',
+				output: htmlTags.scripts
+			});
+		}).toThrow(new Error('mkdir error'));
+		expect(chunksWebpackPlugin.getOutputFilePath).not.toHaveBeenCalled();
+	});
+
+	it('Should call the createAsset function with the Node.js FS and writeFile error', () => {
+		chunksWebpackPlugin.getOutputFilePath = jest.fn();
+
+		chunksWebpackPlugin.compilation = compilationWebpack;
+		chunksWebpackPlugin.outputPath = compilationWebpack.options.output.path;
+		chunksWebpackPlugin.outpathFromFilename = 'templates/';
+		chunksWebpackPlugin.fs = generateMockFs({ writeFileError: true });
+
+		chunksWebpackPlugin.options.outputPath = '/chunks-webpack-plugin/example/dist/templates';
+		chunksWebpackPlugin.options.emitAssetsWithCompilation = false;
+
+		expect(() => {
+			chunksWebpackPlugin.createAsset({
+				filename: 'templates/app-a-scripts.html',
+				output: htmlTags.scripts
+			});
+		}).toThrow(new Error('writeFile error'));
+		expect(chunksWebpackPlugin.getOutputFilePath).toHaveBeenCalled();
+	});
+});
+
+describe('ChunksWebpackPlugin getOutputFilePath', () => {
+	it('Should call the getOutputFilePath function', () => {
+		chunksWebpackPlugin.outputPath = compilationWebpack.options.output.path;
+		const result = chunksWebpackPlugin.getOutputFilePath('templates/app-a-scripts.html');
+
+		expect(result).toBe('/chunks-webpack-plugin/example/dist/templates/app-a-scripts.html');
+	});
+
+	it('Should call the getOutputFilePath function with a filename that starts by a slashe', () => {
+		chunksWebpackPlugin.outputPath = compilationWebpack.options.output.path;
+		const result = chunksWebpackPlugin.getOutputFilePath('/templates/app-a-scripts.html');
+
+		expect(result).toBe('/chunks-webpack-plugin/example/dist/templates/app-a-scripts.html');
 	});
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@
  * @author: Yoriiis aka Joris DANIEL <joris.daniel@gmail.com>
  * @description: ChunksWebpackPlugin create HTML files to serve your webpack bundles. It is very convenient with multiple entrypoints and it works without configuration.
  * {@link https://github.com/yoriiis/chunks-webpack-plugins}
- * @copyright 2020 Joris DANIEL
+ * @copyright 2021 Joris DANIEL
  **/
 
 import { Compiler } from 'webpack';
@@ -46,7 +46,6 @@ interface Fs {
 export = class ChunksWebpackPlugin {
 	options: {
 		outputPath: null | string;
-		emitAssetsWithCompilation: boolean;
 		filename: string;
 		templateStyle: string;
 		templateScript: string;
@@ -75,7 +74,6 @@ export = class ChunksWebpackPlugin {
 				templateScript: '<script src="{{chunk}}"></script>',
 				outputPath: null,
 				customFormatTags: false,
-				emitAssetsWithCompilation: true,
 				generateChunksManifest: false,
 				generateChunksFiles: true
 			},
@@ -388,17 +386,16 @@ export = class ChunksWebpackPlugin {
 	}
 
 	/**
-	 * Create asset by the webpack compilation (default) or the webpack built-in Node.js File System
+	 * Create asset by the webpack compilation or the webpack built-in Node.js File System
+	 * The outputPath parameter allows to override the default webpack output path
 	 * @param {Object} options
 	 * @param {String} options.filename Filename
 	 * @param {String} options.output File content
 	 */
 	createAsset({ filename, output }: { filename: string; output: string }): void {
-		if (this.options.emitAssetsWithCompilation) {
-			this.compilation.emitAsset(filename, new RawSource(output, false));
-		} else {
+		if (this.options.outputPath) {
 			this.fs.mkdir(
-				`${this.options.outputPath}/${this.outpathFromFilename}`,
+				`${this.outputPath}/${this.outpathFromFilename}`,
 				{ recursive: true },
 				(error: Error) => {
 					if (error) throw error;
@@ -409,6 +406,8 @@ export = class ChunksWebpackPlugin {
 					});
 				}
 			);
+		} else {
+			this.compilation.emitAsset(filename, new RawSource(output, false));
 		}
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,12 @@ interface Manifest {
 	};
 }
 
+// Describe the shape of the webpack built-in Node.js File System
+interface Fs {
+	mkdir: Function;
+	writeFile: Function;
+}
+
 export = class ChunksWebpackPlugin {
 	options: {
 		outputPath: null | string;
@@ -49,7 +55,7 @@ export = class ChunksWebpackPlugin {
 		generateChunksFiles: boolean;
 	};
 	manifest: Manifest;
-	fs: any;
+	fs!: Fs;
 	compilation: any;
 	isWebpack4: Boolean;
 	entryNames!: Array<string>;
@@ -69,9 +75,9 @@ export = class ChunksWebpackPlugin {
 				templateScript: '<script src="{{chunk}}"></script>',
 				outputPath: null,
 				customFormatTags: false,
+				emitAssetsWithCompilation: true,
 				generateChunksManifest: false,
-				generateChunksFiles: true,
-				emitAssetsWithCompilation: true
+				generateChunksFiles: true
 			},
 			options
 		);
@@ -83,7 +89,6 @@ export = class ChunksWebpackPlugin {
 
 	/**
 	 * Apply function is automatically called by the Webpack main compiler
-	 *
 	 * @param {Object} compiler The Webpack compiler variable
 	 */
 	apply(compiler: Compiler): void {
@@ -94,7 +99,6 @@ export = class ChunksWebpackPlugin {
 
 	/**
 	 * Hook expose by the Webpack compiler
-	 *
 	 * @param {Object} compilation The Webpack compilation variable
 	 */
 	hookCallback(compilation: object): void {
@@ -137,7 +141,6 @@ export = class ChunksWebpackPlugin {
 
 	/**
 	 * Process for each entry
-
 	 * @param {String} entryName Entrypoint name
 	 */
 	processEntry(entryName: string): void {
@@ -160,7 +163,6 @@ export = class ChunksWebpackPlugin {
 	/**
 	 * Get the public path from Webpack configuation
 	 * and add slash at the end if necessary
-	 *
 	 * @return {String} The public path
 	 */
 	getPublicPath(): string {
@@ -183,7 +185,6 @@ export = class ChunksWebpackPlugin {
 	/**
 	 * Get the output path from Webpack configuation
 	 * or from constructor options
-	 *
 	 * @return {String} The output path
 	 */
 	getOutputPath(): string | null {
@@ -195,9 +196,8 @@ export = class ChunksWebpackPlugin {
 	}
 
 	/**
-	 * Get the output path inside the filename if exist
-	 * Filename can contains directory (automatically created by the compilation
-	 *
+	 * Get the output path inside the filename if it exists
+	 * Filename can contain a directory (created automatically by the compilation)
 	 * @returns {String} The outpath path extract from the filename
 	 */
 	getOutputPathFromFilename(): string {
@@ -207,7 +207,6 @@ export = class ChunksWebpackPlugin {
 
 	/**
 	 * Check if the outputPath is valid, a string and absolute
-	 *
 	 * @returns {Boolean} outputPath is valid
 	 */
 	isValidOutputPath(): boolean {
@@ -216,7 +215,6 @@ export = class ChunksWebpackPlugin {
 
 	/**
 	 * Get entrypoint names from the compilation
-	 *
 	 * @return {Array} List of entrypoint names
 	 */
 	getEntryNames(): Array<string> {
@@ -227,7 +225,6 @@ export = class ChunksWebpackPlugin {
 	 * Get files list by entrypoint name
 	 *
 	 * @param {String} entryName Entrypoint name
-	 *
 	 * @return {Array} List of entrypoint names
 	 */
 	getFiles(entryName: string): Array<string> {
@@ -236,10 +233,9 @@ export = class ChunksWebpackPlugin {
 
 	/**
 	 * Get HTML tags from chunks
-	 *
-	 * @param {Object} chunks Chunks sorted by type (style, script)
-	 * @param {Object} Entrypoint Entrypoint object part of a single ChunkGroup
-	 *
+	 * @param {Object} options
+	 * @param {Object} options.chunks Chunks sorted by type (style, script)
+	 * @param {Object} options.Entrypoint Entrypoint object part of a single ChunkGroup
 	 * @returns {String} HTML tags by entrypoints
 	 */
 	getHtmlTags({
@@ -267,9 +263,7 @@ export = class ChunksWebpackPlugin {
 
 	/**
 	 * Sorts all chunks by type (styles or scripts)
-	 *
 	 * @param {Array} files List of files by entrypoint name
-	 *
 	 * @returns {Object} All chunks sorted by extension type
 	 */
 	sortsChunksByType(files: Array<string>): Chunks {
@@ -285,9 +279,7 @@ export = class ChunksWebpackPlugin {
 
 	/**
 	 * Generate HTML styles and scripts tags for each entrypoints
-	 *
 	 * @param {Object} chunks The list of chunks of chunkGroups sorted by type
-	 *
 	 * @returns {Object} HTML tags with all assets for an entrypoint and sorted by type
 	 */
 	formatTags(chunks: Chunks): HtmlTags {
@@ -305,9 +297,7 @@ export = class ChunksWebpackPlugin {
 
 	/**
 	 * Check if the publicPath need an ending slash
-	 *
 	 * @param {String} publicPath Public path
-	 *
 	 * @returns {Boolean} The public path need an ending slash
 	 */
 	isPublicPathNeedsEndingSlash(publicPath: string): boolean {
@@ -316,10 +306,8 @@ export = class ChunksWebpackPlugin {
 
 	/**
 	 * Check if file extension correspond to the type parameter
-	 *
 	 * @param {String} file File path
 	 * @param {String} type File extension
-	 *
 	 * @returns {Boolean} File extension is valid
 	 */
 	isValidExtensionByType(file: string, type: string): boolean {
@@ -328,7 +316,6 @@ export = class ChunksWebpackPlugin {
 
 	/**
 	 * Check if datas from customFormatTags are valid
-	 *
 	 * @param {Object} htmlTags Formatted HTML tags by styles and scripts keys
 	 */
 	isValidCustomFormatTagsDatas(htmlTags: HtmlTags): boolean {
@@ -342,9 +329,9 @@ export = class ChunksWebpackPlugin {
 	/**
 	 * Update the class property manifest
 	 * which contains all chunks informations by entrypoint
-	 *
-	 * @param {String} entryName Entrypoint name
-	 * @param {Object} chunks List of styles and scripts chunks by entrypoint
+	 * @param {Object} options
+	 * @param {String} options.entryName Entrypoint name
+	 * @param {Object} options.chunks List of styles and scripts chunks by entrypoint
 	 */
 	updateManifest({ entryName, chunks }: { entryName: string; chunks: Chunks }): void {
 		this.manifest[entryName] = {
@@ -371,9 +358,9 @@ export = class ChunksWebpackPlugin {
 
 	/**
 	 * Create file with HTML tags for each entrypoints
-	 *
-	 * @param {String} entryName Entrypoint name
-	 * @param {Object} htmlTags Generated HTML of script and styles tags
+	 * @param {Object} options
+	 * @param {String} options.entryName Entrypoint name
+	 * @param {Object} options.htmlTags Generated HTML of script and styles tags
 	 */
 	createHtmlChunksFiles({
 		entryName,
@@ -401,12 +388,12 @@ export = class ChunksWebpackPlugin {
 	}
 
 	/**
-	 * Create asset by the webpack compilation (default) or Node.js FS
+	 * Create asset by the webpack compilation (default) or the webpack built-in Node.js File System
 	 * @param {Object} options
-	 * @param {String} filename Filename
-	 * @param {String} output File content
+	 * @param {String} options.filename Filename
+	 * @param {String} options.output File content
 	 */
-	createAsset({ filename, output }: { filename: string; output: string }) {
+	createAsset({ filename, output }: { filename: string; output: string }): void {
 		if (this.options.emitAssetsWithCompilation) {
 			this.compilation.emitAsset(filename, new RawSource(output, false));
 		} else {
@@ -436,7 +423,6 @@ export = class ChunksWebpackPlugin {
 
 	/**
 	 * Throw an error
-	 *
 	 * @param {String} message Text to display in the error
 	 */
 	setError(message: string) {


### PR DESCRIPTION
Addition of `outputPath` to override the webpack output path.
Generate assets by the webpack compilation or the webpack built-in FS
