### PR TITLE
Fix automatique public path generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         node-version: [16, 18, 20]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     uses: yoriiis/actions/.github/workflows/test-and-build.yml@main
     with:
       node-version: ${{ matrix.node-version }}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -53,3 +53,8 @@ export interface PluginOptions {
 	generateChunksManifest: boolean;
 	generateChunksFiles: boolean;
 }
+
+export interface PublicPath {
+	html: string;
+	manifest: string;
+}


### PR DESCRIPTION
The automatic generation of the public path does not work as it should. With auto mode, the path should be relative.

Now with this mode, the path in the manifest and in the generated html files will be relative to the generated assets.

Fix #92

**Breaking changes in case of the `auto` mode**