### PR TITLE
Make config optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export default class ChunksWebpackPlugin {
 	 * Instanciate the constructor
 	 * @param options Plugin options
 	 */
-	constructor(options: PluginOptions) {
+	constructor(options?: Partial<PluginOptions>) {
 		// Merge default options with user options
 		this.options = Object.assign(
 			{


### PR DESCRIPTION
## Description

Change constructor from `options: PluginOptions` to `options?: Partial<PluginOptions>`

## Specific Changes proposed
Change constructor from `options: PluginOptions` to `options?: Partial<PluginOptions>`

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chome, Firefox, IE)
  - [ ] Docs/guides updated
  - [ ] Example created on CodePen
- [ ] Reviewed by contributors
